### PR TITLE
Add README section for custom metadata type

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,9 @@ Add `graphql-pagination` to your Gemfile, you can use `kaminari-activerecord` or
 
 Value returned by query resolver must be a kaminari object or implements its page scope methods (`current_page`, `limit_value`, `total_count`, `total_pages`).
 
-
 ## GraphQL query
 
-```
+```graphql
 {
   fruits(page: 2, limit: 2) {
     collection {
@@ -49,29 +48,52 @@ Value returned by query resolver must be a kaminari object or implements its pag
 }
 ```
 
-```
+```json
 {
-  'data': {
-    'checklists': {
-      'collection': [
+  "data": {
+    "checklists": {
+      "collection": [
         {
-          'id': '93938bb3-7a6c-4d35-9961-cbb2d4c9e9ac',
-          'name': 'Apple'
+          "id": "93938bb3-7a6c-4d35-9961-cbb2d4c9e9ac",
+          "name": "Apple"
         },
         {
-          'id': 'b1ee93b2-579a-4107-8454-119bba5afb63',
-          'name': 'Mango'
+          "id": "b1ee93b2-579a-4107-8454-119bba5afb63",
+          "name": "Mango"
         }
       ],
-      'metadata': {
-        'totalPages': 25,
-        'totalCount': 50,
-        'currentPage': 2,
-        'limitValue': 2
+      "metadata": {
+        "totalPages": 25,
+        "totalCount": 50,
+        "currentPage": 2,
+        "limitValue": 2
       }
     }
   }
 }
+```
+
+## Custom Metadata
+
+By default, the following fields are present in the metadata block:
+
+```graphql
+metadata {
+  totalPages
+  totalCount
+  currentPage
+  limitValue
+}
+```
+
+These fields correspond to the `GraphqlPagination::CollectionMetadataType` used to provide the pagination information for the collection of data delivered. If you want to add more metadata fields to this block, you can do so by extending this `CollectionMetadataType`:
+
+```ruby
+class MyMetadataType < GraphqlPagination::CollectionMetadataType
+  field :custom_field, String, null: false
+end
+
+field :fruits, Types::FruitType.collection_type(metadata_type: MyMetadataType)
 ```
 
 ## Contributing
@@ -81,4 +103,3 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/renofi
 ## License
 
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
-


### PR DESCRIPTION
As a follow-up to https://github.com/RenoFi/graphql-pagination/pull/33, this now adds more information in the README regarding custom metadata types. :stars: 

It's pretty brief, let me know if you have any ideas on how to improve this. Thank you!