### PR TITLE
Fix caching of collection types

### DIFF
--- a/lib/graphql_pagination/collection_type.rb
+++ b/lib/graphql_pagination/collection_type.rb
@@ -1,7 +1,8 @@
 module GraphqlPagination
   module CollectionType
     def collection_type(metadata_type: GraphqlPagination::CollectionMetadataType)
-      @collection_type ||= begin
+      @collection_types ||= {}
+      @collection_types[metadata_type] ||= begin
         type_name = "#{graphql_name}Collection"
         source_type = self
 

--- a/spec/graphql_pagination/collection_type_spec.rb
+++ b/spec/graphql_pagination/collection_type_spec.rb
@@ -11,5 +11,26 @@ RSpec.describe GraphqlPagination::CollectionType do
     it do
       expect(collection_type.fields.keys).to match_array(%w[collection metadata])
     end
+
+    context "with custom metadata type" do
+      let(:collection_type) { type.collection_type }
+      let(:custom_collection_type) { type.collection_type(metadata_type: metadata_type) }
+
+      let(:metadata_type) do
+        Class.new(GraphqlPagination::CollectionMetadataType) do
+          graphql_name 'CustomCollectionMetadataType'
+          field :foo, String, null: true
+        end
+      end
+
+      it "returns an appropriate collection type based on metadata_type argument" do
+        expect(collection_type.fields['metadata'].type.of_type.fields.keys).not_to include('foo')
+        expect(custom_collection_type.fields['metadata'].type.of_type.fields.keys).to include('foo')
+      end
+
+      it "caches the type for future use" do
+        expect(custom_collection_type).to be(type.collection_type(metadata_type: metadata_type))
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description

The collection type can be customized with a metadata_type argument. If
one chooses to use different metadata types for the same GQL type, then
the first type will be cached and the custom metadata type will be
ignored.

## How Has This Been Tested?

RSpec