### PR TITLE
Add support for a custom collection base type

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,25 @@ Value returned by query resolver must be a kaminari object or implements its pag
 }
 ```
 
+## Custom Base
+
+By default the resulting collection_type class is a direct descendant of
+graphql-ruby's GraphQL::Schema::Object, however you may require your own
+behaviours and properties on the collection class itself such as defining
+[custom visibility](https://graphql-ruby.org/authorization/visibility.html#object-visibility).
+
+This can be done by passing in your own custom class, to be inherited from:
+
+```ruby
+class MyBaseType < GraphQL::Schema::Object
+  def self.visible?(context)
+    # ...
+  end
+end
+
+field :fruits, Types::FruitType.collection_type(collection_base: MyBaseType)
+```
+
 ## Custom Metadata
 
 By default, the following fields are present in the metadata block:

--- a/lib/graphql_pagination.rb
+++ b/lib/graphql_pagination.rb
@@ -5,6 +5,7 @@ require 'graphql/schema/object'
 module GraphqlPagination
 end
 
+require 'graphql_pagination/collection_base_error'
 require 'graphql_pagination/collection_type'
 require 'graphql_pagination/collection_metadata_type'
 

--- a/lib/graphql_pagination/collection_base_error.rb
+++ b/lib/graphql_pagination/collection_base_error.rb
@@ -1,0 +1,8 @@
+module GraphqlPagination
+  class CollectionBaseError < StandardError
+    def message
+      "CollectionBaseError: The collection_type attribute must inherit from
+      or be a GraphQL::Schema::Object"
+    end
+  end
+end

--- a/lib/graphql_pagination/collection_type.rb
+++ b/lib/graphql_pagination/collection_type.rb
@@ -1,12 +1,18 @@
 module GraphqlPagination
   module CollectionType
-    def collection_type(metadata_type: GraphqlPagination::CollectionMetadataType)
+    def collection_type(
+      collection_base: GraphQL::Schema::Object,
+      metadata_type: GraphqlPagination::CollectionMetadataType
+    )
+      fail CollectionBaseError unless collection_base <= GraphQL::Schema::Object
+
       @collection_types ||= {}
-      @collection_types[metadata_type] ||= begin
+      @collection_types[collection_base] ||= {}
+      @collection_types[collection_base][metadata_type] ||= begin
         type_name = "#{graphql_name}Collection"
         source_type = self
 
-        Class.new(GraphQL::Schema::Object) do
+        Class.new(collection_base) do
           graphql_name type_name
           field :collection, [source_type], null: false
           field :metadata, metadata_type, null: false

--- a/spec/graphql_pagination/collection_type_spec.rb
+++ b/spec/graphql_pagination/collection_type_spec.rb
@@ -32,5 +32,38 @@ RSpec.describe GraphqlPagination::CollectionType do
         expect(custom_collection_type).to be(type.collection_type(metadata_type: metadata_type))
       end
     end
+
+    context "with custom collection base" do
+      let(:collection_base) do
+        Class.new(GraphQL::Schema::Object) do
+          graphql_name 'CustomCollectionBase'
+          field :foo, String, null: true
+          def self.visible?(_) = false
+        end
+      end
+
+      let(:collection_type) { type.collection_type }
+      let(:custom_collection_type) { type.collection_type(collection_base: collection_base) }
+
+      it "returns an appropriate collection type based on collection_base argument" do
+        expect(collection_type.visible?(nil)).to be true
+        expect(custom_collection_type.visible?(nil)).to be false
+
+        expect(collection_type.fields.keys).not_to include('foo')
+        expect(custom_collection_type.fields.keys).to include('foo')
+      end
+
+      it "caches the type for future use" do
+        expect(custom_collection_type).to be(type.collection_type(collection_base: collection_base))
+      end
+
+      context "when collection_base is not a GraphQL::Schema::Object" do
+        let(:collection_base) { Class.new }
+
+        it "raises an error" do
+          expect { custom_collection_type }.to raise_error(GraphqlPagination::CollectionBaseError)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
I've been finding limitations in that the resulting field / object created by this gem, representing this collection cannot be customised.

Proposed change allows the passing in of a custom base type, such that the resulting collection object itself can be customised.

Included in PR:
 - Spec updates
 - Readme update
 - Required code change.

# As added to README:

## Custom Base

By default the resulting collection_type class is a direct descendant of graphql-ruby's GraphQL::Schema::Object, however you may require your own behaviours and properties on the collection class itself such as defining
[custom visibility](https://graphql-ruby.org/authorization/visibility.html#object-visibility).

This can be done by passing in your own custom class, to be inherited from:

```ruby
class MyBaseType < GraphQL::Schema::Object
  def self.visible?(context)
    # ...
  end
end

field :fruits, Types::FruitType.collection_type(collection_base: MyBaseType)
```