### PR TITLE
Add auto-generated collection type descriptions

### DIFF
--- a/lib/graphql_pagination/collection_type.rb
+++ b/lib/graphql_pagination/collection_type.rb
@@ -14,6 +14,7 @@ module GraphqlPagination
 
         Class.new(collection_base) do
           graphql_name type_name
+          description "#{graphql_name} type"
           field :collection, [source_type], null: false, description: "A collection of paginated #{graphql_name}"
           field :metadata, metadata_type, null: false, description: "Pagination Metadata for navigating the Pagination"
 

--- a/spec/graphql_pagination/collection_metadata_type_spec.rb
+++ b/spec/graphql_pagination/collection_metadata_type_spec.rb
@@ -1,7 +1,13 @@
 RSpec.describe GraphqlPagination::CollectionMetadataType do
   describe '.fields' do
-    it do
+    it 'has expected fields' do
       expect(described_class.fields.keys).to match_array(%w[currentPage limitValue totalCount totalPages])
+    end
+
+    it 'has descriptions on fields' do
+      described_class.fields.each do |key, value|
+        expect(described_class.fields[key].description).to be_present
+      end
     end
   end
 end

--- a/spec/graphql_pagination/collection_type_spec.rb
+++ b/spec/graphql_pagination/collection_type_spec.rb
@@ -8,8 +8,12 @@ RSpec.describe GraphqlPagination::CollectionType do
       end
     end
 
-    it do
+    it "has expected fields" do
       expect(collection_type.fields.keys).to match_array(%w[collection metadata])
+    end
+
+    it "has description" do
+      expect(collection_type.description).to be_present
     end
 
     context "with custom metadata type" do
@@ -31,6 +35,10 @@ RSpec.describe GraphqlPagination::CollectionType do
       it "caches the type for future use" do
         expect(custom_collection_type).to be(type.collection_type(metadata_type: metadata_type))
       end
+
+      it "has description" do
+        expect(custom_collection_type.fields['metadata'].description).to be_present
+      end
     end
 
     context "with custom collection base" do
@@ -51,6 +59,10 @@ RSpec.describe GraphqlPagination::CollectionType do
 
         expect(collection_type.fields.keys).not_to include('foo')
         expect(custom_collection_type.fields.keys).to include('foo')
+      end
+
+      it "has description" do
+        expect(custom_collection_type.fields['collection'].description).to be_present
       end
 
       it "caches the type for future use" do


### PR DESCRIPTION
## Description, motivation and context

To continue the related PR below, this adds descriptions to the collection types. The prior change worked well but the [graphql schema linter](https://github.com/RenoFi/graphql-pagination/pull/149) we're using caught these additional types missing descriptions. I believe this should do the job since the generated collection type objects generated inherit from `GraphQL::Schema::Object` which has the description method on it.

It also adds some basic specs.

Feel free to suggest a different name for the auto-generated name. 

## Related issue(s) or PR(s)

https://github.com/RenoFi/graphql-pagination/pull/149
