### PR TITLE
Add description field to CollectionMetadataType

### DIFF
--- a/lib/graphql_pagination/collection_metadata_type.rb
+++ b/lib/graphql_pagination/collection_metadata_type.rb
@@ -1,5 +1,6 @@
 module GraphqlPagination
   class CollectionMetadataType < GraphQL::Schema::Object
+    description "Type for CollectionMetadataType"
     field :current_page, Integer, null: false, description: "Current Page of loaded data"
     field :limit_value, Integer, null: false, description: "The number of items per page"
     field :total_count, Integer, null: false, description: "The total number of items to be paginated"

--- a/spec/graphql_pagination/collection_metadata_type_spec.rb
+++ b/spec/graphql_pagination/collection_metadata_type_spec.rb
@@ -1,4 +1,8 @@
 RSpec.describe GraphqlPagination::CollectionMetadataType do
+  it 'has description' do
+    expect(described_class.description).to be_present
+  end
+
   describe '.fields' do
     it 'has expected fields' do
       expect(described_class.fields.keys).to match_array(%w[currentPage limitValue totalCount totalPages])


### PR DESCRIPTION
## Description, motivation and context

A final continuation of adding missing types to satisfy graphql schema linters. Unfortunately, I missed this one in the prior PR. 

Also added corresponding spec.

Example failure from the linter for search-ability.
```
$ yarn run graphql-schema-linter schema.graphql

4109:1 The object type `CollectionMetadata` is missing a description.           types-have-descriptions
```

## Related issue(s) or PR(s)

#150
