### PR TITLE
fix loading schema object - closes #183

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     graphql-pagination (2.2.0)
-      graphql (~> 2.0)
+      graphql (>= 2.4.7)
 
 GEM
   remote: https://rubygems.org/
@@ -36,7 +36,7 @@ GEM
     diff-lcs (1.5.1)
     drb (2.2.1)
     fiber-storage (1.0.0)
-    graphql (2.4.4)
+    graphql (2.4.7)
       base64
       fiber-storage
     i18n (1.14.6)
@@ -47,9 +47,9 @@ GEM
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
     language_server-protocol (3.17.0.3)
-    logger (1.6.1)
+    logger (1.6.2)
     method_source (1.1.0)
-    minitest (5.25.2)
+    minitest (5.25.4)
     parallel (1.26.3)
     parser (3.3.6.0)
       ast (~> 2.4.1)
@@ -73,7 +73,7 @@ GEM
     rspec-mocks (3.13.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-support (3.13.1)
+    rspec-support (3.13.2)
     rubocop (1.69.1)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -91,7 +91,7 @@ GEM
     rubocop-rspec (3.2.0)
       rubocop (~> 1.61)
     ruby-progressbar (1.13.0)
-    securerandom (0.3.2)
+    securerandom (0.4.0)
     timeout (0.4.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require 'bundler/setup'
-require 'rack_graphql'
+require 'graphql_pagination'
 require 'pry'
 require 'irb'
 

--- a/graphql-pagination.gemspec
+++ b/graphql-pagination.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'graphql', '~> 2.0'
+  spec.add_dependency 'graphql', '>= 2.4.7'
 end

--- a/lib/graphql_pagination.rb
+++ b/lib/graphql_pagination.rb
@@ -1,6 +1,6 @@
 require 'graphql_pagination/version'
 require 'graphql'
-require 'graphql/schema/object'
+require 'graphql/schema'
 
 module GraphqlPagination
 end


### PR DESCRIPTION
## Description, motivation and context
https://github.com/rmosolgo/graphql-ruby/commit/d3e101057247780583465db6c577799b6fe504b7 changed how built in types are loaded and we started experiencing `uninitialized constant GraphQL::Schema::Object`
 