### PR TITLE
Fix Dependabot security alerts: update activesupport and json

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,13 +7,13 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (8.1.2)
-      activesupport (= 8.1.2)
-    activerecord (8.1.2)
-      activemodel (= 8.1.2)
-      activesupport (= 8.1.2)
+    activemodel (8.1.2.1)
+      activesupport (= 8.1.2.1)
+    activerecord (8.1.2.1)
+      activemodel (= 8.1.2.1)
+      activesupport (= 8.1.2.1)
       timeout (>= 0.4.0)
-    activesupport (8.1.2)
+    activesupport (8.1.2.1)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.3.1)
@@ -49,7 +49,7 @@ GEM
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    json (2.18.1)
+    json (2.19.2)
     kaminari-activerecord (1.2.2)
       activerecord
       kaminari-core (= 1.2.2)
@@ -58,7 +58,8 @@ GEM
     lint_roller (1.1.0)
     logger (1.7.0)
     method_source (1.1.0)
-    minitest (6.0.1)
+    minitest (6.0.2)
+      drb (~> 2.0)
       prism (~> 1.5)
     openssl (4.0.0)
     ostruct (0.6.3)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description, motivation and context

Updates vulnerable dependencies in `Gemfile.lock` to resolve 4 Dependabot security alerts:

### Changes

| Package | Old Version | New Version | Severity | CVEs Fixed |
| --- | --- | --- | --- | --- |
| activesupport | 8.1.2 | 8.1.2.1 | MEDIUM | CVE-2026-33176 (DoS in number helpers), CVE-2026-33170 (XSS in SafeBuffer#%), CVE-2026-33169 (ReDoS in number_to_delimited) |
| json | 2.18.1 | 2.19.2 | HIGH | CVE-2026-33210 (format string injection) |
| minitest | 6.0.1 | 6.0.2 | — | Transitive dependency update |

This is a lockfile-only change — no changes to `Gemfile` or `.gemspec`. The version bumps are identical to those proposed by Dependabot on `dependabot/bundler/activesupport-8.1.2.1` and `dependabot/bundler/json-2.19.2`, combined into a single PR for convenience.

## Related tickets(s), PR(s) or slack message:

- SEC-24
- https://github.com/RenoFi/graphql-pagination/security/dependabot/16
- https://github.com/RenoFi/graphql-pagination/security/dependabot/17
- https://github.com/RenoFi/graphql-pagination/security/dependabot/18
- https://github.com/RenoFi/graphql-pagination/security/dependabot/19
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SEC-24](https://linear.app/renofi/issue/SEC-24/dependabot-graphql-pagination-4-open-security-alerts)

<div><a href="https://cursor.com/agents/bc-4b39ebab-c244-400b-958f-53aa071c665b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b39ebab-c244-400b-958f-53aa071c665b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

