### PR TITLE
Mark CollectionMetadataType shareable under Federation 2

### DIFF
--- a/lib/graphql_pagination/collection_metadata_type.rb
+++ b/lib/graphql_pagination/collection_metadata_type.rb
@@ -1,5 +1,12 @@
 module GraphqlPagination
   class CollectionMetadataType < GraphQL::Schema::Object
+    if defined?(ApolloFederation::Object) && defined?(Reconf) &&
+        Gem::Version.new(Reconf.fetch("renoql.federation_version") { "1.0" }.to_s) >= Gem::Version.new("2.0.0")
+      include ApolloFederation::Object
+
+      shareable
+    end
+
     description "Type for CollectionMetadataType"
     field :current_page, Integer, null: false, description: "Current Page of loaded data"
     field :limit_value, Integer, null: false, description: "The number of items per page"


### PR DESCRIPTION
## Description, motivation and context

Every RenoFi subgraph that uses pagination declares `CollectionMetadataType`, which causes Apollo Federation 2 composition to fail with `INVALID_FIELD_SHARING` on `CollectionMetadata.{currentPage, limitValue, totalCount, totalPages}`.

This PR conditionally marks the type `@shareable` when:
- `ApolloFederation::Object` is loaded, and
- `Reconf` is loaded with `renoql.federation_version >= 2.0`.

Standalone consumers (no apollo-federation, no reconf) keep working unchanged. Same conditional pattern renoql uses for `Query.health`.

## Related tickets(s), PR(s) or slack message:

DEVOPS-226

## Security

No security concerns.