### PR TITLE
Defer CollectionMetadataType load so Fed 2 @shareable lands

### DIFF
--- a/lib/graphql_pagination.rb
+++ b/lib/graphql_pagination.rb
@@ -3,11 +3,11 @@ require "graphql"
 require "graphql/schema"
 
 module GraphqlPagination
+  autoload :CollectionMetadataType, "graphql_pagination/collection_metadata_type"
 end
 
 require "graphql_pagination/collection_base_error"
 require "graphql_pagination/collection_type"
-require "graphql_pagination/collection_metadata_type"
 require "graphql_pagination/collection_field"
 require "graphql_pagination/paginated_field"
 


### PR DESCRIPTION
## Description, motivation and context

Fixes a load-order bug shipped in 2.6.0. The conditional `@shareable` block on `CollectionMetadataType` evaluates at class-body load time, but the gem eagerly requires `collection_metadata_type.rb` from `lib/graphql_pagination.rb` during `Bundler.require` — before consuming apps configure Reconf. The `defined?(Reconf)` guard always evaluated false; the directive never landed; and consumers' supergraph composition still failed with `INVALID_FIELD_SHARING` on `CollectionMetadata.*`.

This PR changes the eager `require` to `autoload`, so the class body runs the first time something references `GraphqlPagination::CollectionMetadataType` — which happens at GraphQL schema-definition time, well after Reconf is configured. Same effective lazy-load behaviour that re-search 1.8.24 gets via Zeitwerk.

## Related tickets(s), PR(s) or slack message:

DEVOPS-226
Original 2.6.0 PR: https://github.com/RenoFi/graphql-pagination/pull/253

## Security

No security concerns.